### PR TITLE
queue_work spec should show list of errors

### DIFF
--- a/src/riak_pipe.erl
+++ b/src/riak_pipe.erl
@@ -322,7 +322,7 @@ queue_work(Pipe, Input) ->
 -spec queue_work(Pipe::pipe(),
                  Input::term(),
                  Timeout::riak_pipe_vnode:qtimeout())
-         -> ok | {error, riak_pipe_vnode:qerror()}.
+         -> ok | {error, [riak_pipe_vnode:qerror()]}.
 queue_work(#pipe{fittings=[{_,Head}|_]}, Input, Timeout)
   when Timeout =:= infinity; Timeout =:= noblock ->
     riak_pipe_vnode:queue_work(Head, Input, Timeout).


### PR DESCRIPTION
Error detected via dialyzer on riak_test - `pipe_verify_exceptions` expects and gets a list of exceptions (as returned from the child function `riak_pipe_vnode:queue_work/3`